### PR TITLE
Fix file name bug

### DIFF
--- a/source/WindowsAPICodePack/Shell/CommonFileDialogs/CommonFileDialog.cs
+++ b/source/WindowsAPICodePack/Shell/CommonFileDialogs/CommonFileDialog.cs
@@ -278,21 +278,7 @@ namespace Microsoft.WindowsAPICodePack.Dialogs
                     throw new InvalidOperationException(LocalizedMessages.CommonFileDialogMultipleFiles);
                 }
 
-                var returnFilename = filenames[0];
-
-                if(this is CommonSaveFileDialog)
-                {
-                    returnFilename = System.IO.Path.ChangeExtension(returnFilename, this.filters[this.SelectedFileTypeIndex - 1].Extensions[0]);
-                }
-
-                // "If extension is a null reference (Nothing in Visual Basic), the returned string contains the specified path with its
-                // extension removed." Since we do not want to remove any existing extension, make sure the DefaultExtension property is NOT null.
-
-                // if we should, and there is one to set...
-                if (!string.IsNullOrEmpty(DefaultExtension))
-                {
-                    returnFilename = System.IO.Path.ChangeExtension(returnFilename, DefaultExtension);
-                }
+                string returnFilename = filenames[0];
 
                 return returnFilename;
             }

--- a/source/WindowsAPICodePack/Shell/CommonFileDialogs/CommonFileDialog.cs
+++ b/source/WindowsAPICodePack/Shell/CommonFileDialogs/CommonFileDialog.cs
@@ -278,9 +278,7 @@ namespace Microsoft.WindowsAPICodePack.Dialogs
                     throw new InvalidOperationException(LocalizedMessages.CommonFileDialogMultipleFiles);
                 }
 
-                string returnFilename = filenames[0];
-
-                return returnFilename;
+                return filenames[0];
             }
         }
 

--- a/source/WindowsAPICodePack/Shell/Shell.csproj
+++ b/source/WindowsAPICodePack/Shell/Shell.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.WindowsAPICodePack.Shell</AssemblyName>
     <PackageId>NationalInstruments.Microsoft.WindowsAPICodePack.Shell</PackageId>
-    <VersionPrefix>1.1.6</VersionPrefix>
+    <VersionPrefix>1.1.7</VersionPrefix>
     <Title>$(AssemblyName)</Title>
     <Authors>lnowotny;jmeyer</Authors>
     <Company>NI</Company>


### PR DESCRIPTION
We are no longer going to try to replace the extension of a selected file. This is rife with issues. If a similar behavior is ever needed we will need to provide an alternative implementation.