### PR TITLE
Updating NormalizeExtension of CommonFileDialogFilter

### DIFF
--- a/source/WindowsAPICodePack/Shell/CommonFileDialogs/CommonFileDialogFilter.cs
+++ b/source/WindowsAPICodePack/Shell/CommonFileDialogs/CommonFileDialogFilter.cs
@@ -84,6 +84,14 @@ namespace Microsoft.WindowsAPICodePack.Dialogs
             set => showExtensions = value;
         }
 
+        private static string NormalizeExtension(string rawExtension)
+        {
+            rawExtension = rawExtension.Trim();
+            rawExtension = rawExtension.Replace("*.", null);
+            rawExtension = rawExtension.Replace(".", null);
+            return rawExtension;
+        }
+
         /// <summary>Returns a string representation for this filter that includes the display name and the list of extensions.</summary>
         /// <returns>A <see cref="System.String"/>.</returns>
         public override string ToString() => string.Format(System.Globalization.CultureInfo.InvariantCulture,
@@ -117,14 +125,6 @@ namespace Microsoft.WindowsAPICodePack.Dialogs
             }
 
             return extensionList.ToString();
-        }
-
-        private static string NormalizeExtension(string rawExtension)
-        {
-            rawExtension = rawExtension.Trim();
-            rawExtension = rawExtension.Replace("*.", null);
-            rawExtension = rawExtension.Replace(".", null);
-            return rawExtension;
         }
     }
 }

--- a/source/WindowsAPICodePack/Shell/CommonFileDialogs/CommonFileDialogFilter.cs
+++ b/source/WindowsAPICodePack/Shell/CommonFileDialogs/CommonFileDialogFilter.cs
@@ -123,14 +123,7 @@ namespace Microsoft.WindowsAPICodePack.Dialogs
         {
             rawExtension = rawExtension.Trim();
             rawExtension = rawExtension.Replace("*.", null);
-
-            //remove only the first dot so multi-dotted extensions work
-            int indexOfDot = rawExtension.IndexOf('.');
-            if (indexOfDot != -1)
-            {
-                rawExtension.Remove(indexOfDot);
-            }
-
+            rawExtension = rawExtension.Replace(".", null);
             return rawExtension;
         }
     }


### PR DESCRIPTION
We allow both the "*." and "." prefixes to be present on the supplied extensions for the CommonFileDialogFilter, which will both be removed in normalization.